### PR TITLE
[#117325229] Add support for specific http check attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 pingdom-go is a Go client library for the Pingdom API.
 
-This currently only supports working with basic HTTP and ping checks.
+This currently only supports working with basic HTTP (with specific details)
+and ping checks.
 
 **Build Status:** [![Build Status](https://travis-ci.org/russellcardullo/go-pingdom.svg?branch=master)](https://travis-ci.org/russellcardullo/go-pingdom)
 
@@ -66,6 +67,9 @@ Get details for a specific check:
 ```go
 checkDetails, err := client.Checks.Read(12345)
 ```
+
+For checks with detailed information, check the specific details in
+the field `Type` (e.g. `checkDetails.Type.HTTP`).
 
 Update a check:
 

--- a/pingdom/api_responses.go
+++ b/pingdom/api_responses.go
@@ -1,6 +1,9 @@
 package pingdom
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // PingdomResponse represents a general response from the Pingdom API
 type PingdomResponse struct {
@@ -16,25 +19,74 @@ type PingdomError struct {
 
 // CheckResponse represents the json response for a check from the Pingdom API
 type CheckResponse struct {
-	ID                       int    `json:"id"`
-	Name                     string `json:"name"`
-	Resolution               int    `json:"resolution,omitempty"`
-	SendToAndroid            bool   `json:"sendtoandroid,omitempty"`
-	SendToEmail              bool   `json:"sendtoemail,omitempty"`
-	SendToIPhone             bool   `json:"sendtoiphone,omitempty"`
-	SendToSms                bool   `json:"sendtosms,omitempty"`
-	SendToTwitter            bool   `json:"sendtotwitter,omitempty"`
-	SendNotificationWhenDown int    `json:"sendnotificationwhendown,omitempty"`
-	NotifyAgainEvery         int    `json:"notifyagainevery,omitempty"`
-	NotifyWhenBackup         bool   `json:"notifywhenbackup,omitempty"`
-	Created                  int64  `json:"created,omitempty"`
-	Hostname                 string `json:"hostname,omitempty"`
-	Status                   string `json:"status,omitempty"`
-	LastErrorTime            int64  `json:"lasterrortime,omitempty"`
-	LastTestTime             int64  `json:"lasttesttime,omitempty"`
-	LastResponseTime         int64  `json:"lastresponsetime,omitempty"`
-	Paused                   bool   `json:"paused,omitempty"`
-	ContactIds               []int  `json:"contactids,omitempty"`
+	ID                       int               `json:"id"`
+	Name                     string            `json:"name"`
+	Resolution               int               `json:"resolution,omitempty"`
+	SendToAndroid            bool              `json:"sendtoandroid,omitempty"`
+	SendToEmail              bool              `json:"sendtoemail,omitempty"`
+	SendToIPhone             bool              `json:"sendtoiphone,omitempty"`
+	SendToSms                bool              `json:"sendtosms,omitempty"`
+	SendToTwitter            bool              `json:"sendtotwitter,omitempty"`
+	SendNotificationWhenDown int               `json:"sendnotificationwhendown,omitempty"`
+	NotifyAgainEvery         int               `json:"notifyagainevery,omitempty"`
+	NotifyWhenBackup         bool              `json:"notifywhenbackup,omitempty"`
+	Created                  int64             `json:"created,omitempty"`
+	Hostname                 string            `json:"hostname,omitempty"`
+	Status                   string            `json:"status,omitempty"`
+	LastErrorTime            int64             `json:"lasterrortime,omitempty"`
+	LastTestTime             int64             `json:"lasttesttime,omitempty"`
+	LastResponseTime         int64             `json:"lastresponsetime,omitempty"`
+	Paused                   bool              `json:"paused,omitempty"`
+	ContactIds               []int             `json:"contactids,omitempty"`
+	Type                     CheckResponseType `json:"type,omitempty"`
+}
+
+type CheckResponseType struct {
+	Name string                    `json:"-"`
+	HTTP *CheckResponseHTTPDetails `json:"http,omitempty"`
+}
+
+func (c *CheckResponseType) UnmarshalJSON(b []byte) error {
+	var raw interface{}
+
+	err := json.Unmarshal(b, &raw)
+	if err != nil {
+		return err
+	}
+
+	switch v := raw.(type) {
+	case string:
+		c.Name = v
+	case map[string]interface{}:
+		for k, _ := range v {
+			c.Name = k
+		}
+
+		// Allow continue use json.Unmarshall using a type != Unmarshaller
+		// This avoid enter in a infinite loop
+		type t CheckResponseType
+		var rawCheckDetails t
+
+		err := json.Unmarshal(b, &rawCheckDetails)
+		if err != nil {
+			return err
+		}
+		c.HTTP = rawCheckDetails.HTTP
+	}
+	return nil
+}
+
+// HttpCheck represents a Pingdom http check.
+type CheckResponseHTTPDetails struct {
+	Url              string            `json:"url,omitempty"`
+	Encryption       bool              `json:"encryption,omitempty"`
+	Port             int               `json:"port,omitempty"`
+	Username         string            `json:"username,omitempty"`
+	Password         string            `json:"password,omitempty"`
+	ShouldContain    string            `json:"shouldcontain,omitempty"`
+	ShouldNotContain string            `json:"shouldnotcontain,omitempty"`
+	PostData         string            `json:"postdata,omitempty"`
+	RequestHeaders   map[string]string `json:"requestheaders,omitempty"`
 }
 
 // Return string representation of the PingdomError

--- a/pingdom/api_responses.go
+++ b/pingdom/api_responses.go
@@ -58,6 +58,9 @@ func (c *CheckResponseType) UnmarshalJSON(b []byte) error {
 	case string:
 		c.Name = v
 	case map[string]interface{}:
+		if len(v) != 1 {
+			return fmt.Errorf("Check detalied response `check.type` contains more than one object: %+v", v)
+		}
 		for k, _ := range v {
 			c.Name = k
 		}

--- a/pingdom/api_responses_test.go
+++ b/pingdom/api_responses_test.go
@@ -1,11 +1,66 @@
 package pingdom
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
+
+var detailedCheckJson = `
+{
+	"id" : 85975,
+	"name" : "My check 7",
+	"resolution" : 1,
+	"sendtoemail" : false,
+	"sendtosms" : false,
+	"sendtotwitter" : false,
+	"sendtoiphone" : false,
+	"sendnotificationwhendown" : 0,
+	"notifyagainevery" : 0,
+	"notifywhenbackup" : false,
+	"created" : 1240394682,
+	"type" : {
+		"http" : {
+			"url" : "/",
+			"port" : 80,
+			"requestheaders" : {
+				"User-Agent" : "Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)",
+				"Prama" : "no-cache"
+			}
+		}
+	},
+	"hostname" : "s7.mydomain.com",
+	"status" : "up",
+	"lasterrortime" : 1293143467,
+	"lasttesttime" : 1294064823
+}
+`
 
 func TestPingdomError(t *testing.T) {
 	pe := PingdomError{StatusCode: 400, StatusDesc: "Bad Request", Message: "Missing param foo"}
 	want := "400 Bad Request: Missing param foo"
 	if e := pe.Error(); e != want {
 		t.Errorf("Error() returned '%+v', want '%+v'", e, want)
+	}
+
+}
+
+func TestCheckResponseUnmarshal(t *testing.T) {
+	var ck CheckResponse
+
+	err := json.Unmarshal([]byte(detailedCheckJson), &ck)
+	if err != nil {
+		t.Errorf("Error running json.Unmarshal for CheckResponse: '%+v'", err)
+	}
+	if ck.Type.Name != "http" {
+		t.Errorf("CheckResponse.Type.Name should be populated. returned '%+v', want '%+v'", ck.Type.Name, "http")
+	}
+
+	if ck.Type.HTTP == nil {
+		t.Errorf("CheckResponse.Type.HTTP should be populated.")
+		return
+	}
+	rhl := len(ck.Type.HTTP.RequestHeaders)
+	if rhl != 2 {
+		t.Errorf("CheckResponse.Type.HTTP.RequestHeaders should be populated. length returned '%+v', want '%+v'", rhl, 2)
 	}
 }

--- a/pingdom/check.go
+++ b/pingdom/check.go
@@ -14,7 +14,8 @@ type CheckService struct {
 // Check is an interface representing a pingdom check.
 // Specific check types should implement the methods of this interface
 type Check interface {
-	Params() map[string]string
+	PutParams() map[string]string
+	PostParams() map[string]string
 	Valid() error
 }
 
@@ -55,7 +56,7 @@ func (cs *CheckService) Create(check Check) (*CheckResponse, error) {
 		return nil, err
 	}
 
-	req, err := cs.client.NewRequest("POST", "/api/2.0/checks", check.Params())
+	req, err := cs.client.NewRequest("POST", "/api/2.0/checks", check.PostParams())
 	if err != nil {
 		return nil, err
 	}
@@ -94,9 +95,7 @@ func (cs *CheckService) Update(id int, check Check) (*PingdomResponse, error) {
 		return nil, err
 	}
 
-	params := check.Params()
-	delete(params, "type")
-	req, err := cs.client.NewRequest("PUT", "/api/2.0/checks/"+strconv.Itoa(id), params)
+	req, err := cs.client.NewRequest("PUT", "/api/2.0/checks/"+strconv.Itoa(id), check.PutParams())
 	if err != nil {
 		return nil, err
 	}

--- a/pingdom/check_test.go
+++ b/pingdom/check_test.go
@@ -67,6 +67,9 @@ func TestCheckServiceList(t *testing.T) {
 			Hostname:         "example.com",
 			Resolution:       1,
 			Status:           "up",
+			Type: CheckResponseType{
+				Name: "http",
+			},
 		},
 		CheckResponse{
 			ID:               161748,
@@ -77,6 +80,9 @@ func TestCheckServiceList(t *testing.T) {
 			Hostname:         "mydomain.com",
 			Resolution:       5,
 			Status:           "up",
+			Type: CheckResponseType{
+				Name: "ping",
+			},
 		},
 		CheckResponse{
 			ID:               208655,
@@ -87,6 +93,9 @@ func TestCheckServiceList(t *testing.T) {
 			Hostname:         "example.net",
 			Resolution:       1,
 			Status:           "down",
+			Type: CheckResponseType{
+				Name: "http",
+			},
 		},
 	}
 
@@ -177,7 +186,24 @@ func TestCheckServiceRead(t *testing.T) {
 		Status:                   "up",
 		LastErrorTime:            1293143467,
 		LastTestTime:             1294064823,
+		Type: CheckResponseType{
+			Name: "http",
+			HTTP: &CheckResponseHTTPDetails{
+				Url:              "/",
+				Encryption:       false,
+				Port:             80,
+				Username:         "",
+				Password:         "",
+				ShouldContain:    "",
+				ShouldNotContain: "",
+				PostData:         "",
+				RequestHeaders: map[string]string{
+					"User-Agent": "Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)",
+				},
+			},
+		},
 	}
+
 	if !reflect.DeepEqual(check, want) {
 		t.Errorf("ReadCheck returned %+v, want %+v", check, want)
 	}

--- a/pingdom/check_types_test.go
+++ b/pingdom/check_types_test.go
@@ -6,7 +6,17 @@ import (
 )
 
 func TestHttpCheckParams(t *testing.T) {
-	check := HttpCheck{Name: "fake check", Hostname: "example.com"}
+	check := HttpCheck{
+		Name:     "fake check",
+		Hostname: "example.com",
+		Url:      "/foo",
+		RequestHeaders: map[string]string{
+			"User-Agent": "Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)",
+			"Pragma":     "no-cache",
+		},
+		Username: "user",
+		Password: "pass",
+	}
 	params := check.Params()
 	want := map[string]string{
 		"name":                     "fake check",
@@ -22,7 +32,14 @@ func TestHttpCheckParams(t *testing.T) {
 		"notifyagainevery":         "0",
 		"notifywhenbackup":         "false",
 		"use_legacy_notifications": "false",
-		"type": "http",
+		"type":             "http",
+		"url":              "/foo",
+		"requestheader0":   "Pragma:no-cache",
+		"requestheader1":   "User-Agent:Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)",
+		"auth":             "user:pass",
+		"encryption":       "false",
+		"shouldnotcontain": "",
+		"postdata":         "",
 	}
 
 	if !reflect.DeepEqual(params, want) {
@@ -38,8 +55,20 @@ func TestHttpCheckValid(t *testing.T) {
 
 	check = HttpCheck{Name: "fake check", Hostname: "example.com"}
 	if err := check.Valid(); err == nil {
-		t.Errorf("Valid with invalid check expected error, returned nil")
+		t.Errorf("Valid with invalid check (`Resolution` == 0) expected error, returned nil")
 	}
+
+	check = HttpCheck{
+		Name:             "fake check",
+		Hostname:         "example.com",
+		Resolution:       15,
+		ShouldContain:    "foo",
+		ShouldNotContain: "bar",
+	}
+	if err := check.Valid(); err == nil {
+		t.Errorf("Valid with invalid check (`ShouldContain` and `ShouldNotContain` defined) expected error, returned nil")
+	}
+
 }
 
 func TestPingCheckParams(t *testing.T) {

--- a/pingdom/check_types_test.go
+++ b/pingdom/check_types_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestHttpCheckParams(t *testing.T) {
+func TestHttpCheckPutParams(t *testing.T) {
 	check := HttpCheck{
 		Name:     "fake check",
 		Hostname: "example.com",
@@ -17,7 +17,7 @@ func TestHttpCheckParams(t *testing.T) {
 		Username: "user",
 		Password: "pass",
 	}
-	params := check.Params()
+	params := check.PutParams()
 	want := map[string]string{
 		"name":                     "fake check",
 		"host":                     "example.com",
@@ -32,7 +32,6 @@ func TestHttpCheckParams(t *testing.T) {
 		"notifyagainevery":         "0",
 		"notifywhenbackup":         "false",
 		"use_legacy_notifications": "false",
-		"type":             "http",
 		"url":              "/foo",
 		"requestheader0":   "Pragma:no-cache",
 		"requestheader1":   "User-Agent:Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)",
@@ -43,7 +42,47 @@ func TestHttpCheckParams(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(params, want) {
-		t.Errorf("Check.Params() returned %+v, want %+v", params, want)
+		t.Errorf("Check.PutParams() returned %+v, want %+v", params, want)
+	}
+}
+
+func TestHttpCheckPostParams(t *testing.T) {
+	check := HttpCheck{
+		Name:     "fake check",
+		Hostname: "example.com",
+		Url:      "/foo",
+		RequestHeaders: map[string]string{
+			"User-Agent": "Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)",
+			"Pragma":     "no-cache",
+		},
+		Username: "user",
+		Password: "pass",
+	}
+	params := check.PostParams()
+	want := map[string]string{
+		"name":                     "fake check",
+		"host":                     "example.com",
+		"paused":                   "false",
+		"resolution":               "0",
+		"sendtoemail":              "false",
+		"sendtosms":                "false",
+		"sendtotwitter":            "false",
+		"sendtoiphone":             "false",
+		"sendtoandroid":            "false",
+		"sendnotificationwhendown": "0",
+		"notifyagainevery":         "0",
+		"notifywhenbackup":         "false",
+		"use_legacy_notifications": "false",
+		"type":           "http",
+		"url":            "/foo",
+		"requestheader0": "Pragma:no-cache",
+		"requestheader1": "User-Agent:Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)",
+		"auth":           "user:pass",
+		"encryption":     "false",
+	}
+
+	if !reflect.DeepEqual(params, want) {
+		t.Errorf("Check.PostParams() returned %+v, want %+v", params, want)
 	}
 }
 
@@ -71,9 +110,9 @@ func TestHttpCheckValid(t *testing.T) {
 
 }
 
-func TestPingCheckParams(t *testing.T) {
+func TestPingCheckPostParams(t *testing.T) {
 	check := PingCheck{Name: "fake check", Hostname: "example.com"}
-	params := check.Params()
+	params := check.PostParams()
 	want := map[string]string{
 		"name":                     "fake check",
 		"host":                     "example.com",
@@ -92,7 +131,7 @@ func TestPingCheckParams(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(params, want) {
-		t.Errorf("Check.Params() returned %+v, want %+v", params, want)
+		t.Errorf("Check.PostParams() returned %+v, want %+v", params, want)
 	}
 }
 


### PR DESCRIPTION
[#117325229 Make Terraform Pingdom provider generate HTTPS checks](https://www.pivotaltracker.com/story/show/117325229)
# What

Pingdom API [supports define several specific attributes for HTTP checks](https://www.pingdom.com/resources/api#MethodGet+Detailed+Check+Information), but go-pingdom doesn't manage them.

This functionality will be later used for This functionality will be later used for https://github.com/alphagov/paas-terraform-provider-pingdom/pull/1
# How review test this?

See commits for implementation details.

You can run the test suite by running:

```
go get -d github.com/russellcardullo/go-pingdom
cd $GOPATH/src/github.com/russellcardullo/go-pingdom
git remote add alphagov git@github.com:alphagov/paas-go-pingdom.git
git fetch alphagov
git checkout feature/specific_http_check_attributes

go get ./...

make test
```
# Who?

Anyone but @keymon or @jimconner 
